### PR TITLE
Features: show active user, save on tweet > 280

### DIFF
--- a/lyrebird-cli.py
+++ b/lyrebird-cli.py
@@ -4,25 +4,35 @@ from colorama import Fore, Back, Style, init
 
 init(autoreset=True)
 
+TWEET_LENGTH_LIMIT = 280
+
 CONSUMER_KEY = os.environ.get("CONSUMER_KEY")
 CONSUMER_SECRET = os.environ.get("CONSUMER_SECRET")
 ACCESS_TOKEN = os.environ.get("ACCESS_TOKEN")
 ACCESS_TOKEN_SECRET = os.environ.get("ACCESS_TOKEN_SECRET")
 
-response_id = None
 auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
 auth.set_access_token(ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
 
 api = tweepy.API(auth)
 
+response = {"status_id": None, "status_text": None, "responded_to": None}
 
-def sendTweet(tweet, hashtags, response_id):
+
+def sendTweet(tweet, hashtags, response):
     combined_status = tweet + " " + hashtags
+
+    if len(combined_status) >= TWEET_LENGTH_LIMIT:
+        print(
+            Fore.RED + "Error! Tweet too long! " + str(len(combined_status))
+        ) + " characters"
+        return response
+
     if response_id is None:
         status_response = api.update_status(status=combined_status)
     else:
         status_response = api.update_status(
-            status=combined_status, in_reply_to_status_id=response_id
+            status=combined_status, in_reply_to_status_id=response["id"]
         )
     return {
         "status_id": status_response.id,
@@ -52,7 +62,7 @@ hashtags = input(
 
 while True:
     tweet = input("What do you want to tweet? ")
-    response = sendTweet(tweet, hashtags, response_id)
+    response = sendTweet(tweet, hashtags, response)
     response_id = response["status_id"]
     print(
         "\nReply to: " + Back.BLUE + Fore.BLACK + " " + str(response["status_id"]) + " "

--- a/lyrebird-cli.py
+++ b/lyrebird-cli.py
@@ -28,11 +28,11 @@ def sendTweet(tweet, hashtags, response):
         ) + " characters"
         return response
 
-    if response_id is None:
+    if response["status_id"] is None:
         status_response = api.update_status(status=combined_status)
     else:
         status_response = api.update_status(
-            status=combined_status, in_reply_to_status_id=response["id"]
+            status=combined_status, in_reply_to_status_id=response["status_id"]
         )
     return {
         "status_id": status_response.id,
@@ -63,7 +63,6 @@ hashtags = input(
 while True:
     tweet = input("What do you want to tweet? ")
     response = sendTweet(tweet, hashtags, response)
-    response_id = response["status_id"]
     print(
         "\nReply to: " + Back.BLUE + Fore.BLACK + " " + str(response["status_id"]) + " "
     )

--- a/lyrebird-cli.py
+++ b/lyrebird-cli.py
@@ -33,6 +33,15 @@ def sendTweet(tweet, hashtags, response_id):
 
 print("Welcome to " + Back.GREEN + Fore.BLACK + " Lyrebird! ")
 
+print(
+    "Live-tweeting engaged for account "
+    + Back.MAGENTA
+    + Fore.BLACK
+    + "@"
+    + api.me().screen_name
+)
+
+
 hashtags = input(
     Back.BLUE
     + Fore.BLACK

--- a/lyrebird-cli.py
+++ b/lyrebird-cli.py
@@ -24,8 +24,15 @@ def sendTweet(tweet, hashtags, response):
 
     if len(combined_status) >= TWEET_LENGTH_LIMIT:
         print(
-            Fore.RED + "Error! Tweet too long! " + str(len(combined_status))
-        ) + " characters"
+            Fore.RED
+            + "Error! Tweet too long! "
+            + str(len(combined_status))
+            + " characters"
+        )
+        good = combined_status[:TWEET_LENGTH_LIMIT]
+        bad = combined_status[TWEET_LENGTH_LIMIT:]
+        print(good + Back.RED + Fore.BLACK + bad)
+
         return response
 
     if response["status_id"] is None:
@@ -34,6 +41,7 @@ def sendTweet(tweet, hashtags, response):
         status_response = api.update_status(
             status=combined_status, in_reply_to_status_id=response["status_id"]
         )
+
     return {
         "status_id": status_response.id,
         "status_text": status_response.text,


### PR DESCRIPTION
Two features: 
 - show `api.me().screenname` on startup
 - if combined tweet + hashtags is over the limit, safely failover, keeping the last successful response state, show how much over the tweet was, and continue